### PR TITLE
fix: game search page not properly passing query parameters

### DIFF
--- a/src/routes/game-search/+page.svelte
+++ b/src/routes/game-search/+page.svelte
@@ -116,18 +116,18 @@
 					title={game.title}
 					cover={game.cover_image_id}
 					rating={(game.total_rating ?? 0) / 10 / 2}
-					on:click={() =>
-						goto(
-							`/logs/edit?gameId=${game.id}` +
-								(isNewGame
-									? `&executableName=${executableName}&minutesPlayed=${minutesPlayed}`
-									: '')
-						)}
 				>
 					<svelte:fragment slot="actions">
 						<Tooltip.Root disableHoverableContent>
 							<Tooltip.Trigger>
-								<Button href={`/logs/edit?gameId=${game.id}`} variant="ghost" size="icon">
+								<Button
+									href={`/logs/edit?gameId=${game.id}` +
+										(isNewGame
+											? `&executableName=${executableName}&minutesPlayed=${minutesPlayed}`
+											: '')}
+									variant="ghost"
+									size="icon"
+								>
 									<Plus size={16} />
 								</Button>
 							</Tooltip.Trigger>


### PR DESCRIPTION
This pull request makes a small adjustment to the `src/routes/game-search/+page.svelte` file. The change replaces the `on:click` event handler with a direct `href` attribute in the `Button` component, simplifying the code and ensuring the URL parameters are constructed consistently.